### PR TITLE
chore(ROC-8253): update dependencies to fix vulnerabilities, and introduce DependencyCheck suppressions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 plugins {
-    id 'org.owasp.dependencycheck' version '5.1.0'
+    id 'org.owasp.dependencycheck' version '5.3.2'
     id 'scala'
+    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'com.github.lkishalmi.gatling' version '3.0.2'
     id 'java-gradle-plugin'
     id 'groovy'
-    id 'com.gradle.plugin-publish' version '0.9.8'
+    id 'com.gradle.plugin-publish' version '0.12.0'
     id 'maven-publish'
 }
 
@@ -20,34 +21,73 @@ jar {
     }
 }
 
-/*dependencyCheck {
+dependencyCheck {
     // Specifies if the build should be failed if a CVSS score above a specified level is identified.
     // range of 0-10 fails the build, anything greater and it doesn't fail the build
     failBuildOnCVSS = System.getProperty('dependencyCheck.failBuild') == 'true' ? 0 : 11
     suppressionFile = 'dependency-check-suppressions.xml'
-}*/
-
-repositories {
-    jcenter()
 }
 
+repositories {
+    mavenCentral()
+}
+
+dependencyManagement {
+    dependencies {
+        dependency group: 'io.pebbletemplates', name: 'pebble', version: '3.1.4'
+
+        dependencySet(group: 'org.apache.logging.log4j', version: '2.13.3') {
+            entry 'log4j-api'
+            entry 'log4j-core'
+            entry 'log4j-to-slf4j'
+        }
+
+        dependencySet(group: 'org.scala-lang', version: '2.12.12') {
+            entry 'scala-compiler'
+            entry 'scala-library'
+            entry 'scala-reflect'
+        }
+
+        // solves CVE-2019-12086
+        // remove once spring manager incorporates this changes
+        dependencySet(group: 'com.fasterxml.jackson.core', version: '2.11.2') {
+            entry 'jackson-core'
+            entry 'jackson-databind'
+        }
+
+        // CVE-2019-16869 - brought in by qpid-jms-client
+        dependencySet(group: 'io.netty', version: '4.1.51.Final') {
+            entry 'netty-buffer'
+            entry 'netty-codec'
+            entry 'netty-codec-dns'
+            entry 'netty-codec-http'
+            entry 'netty-codec-http2'
+            entry 'netty-codec-socks'
+            entry 'netty-common'
+            entry 'netty-handler'
+            entry 'netty-handler-proxy'
+            entry 'netty-resolver'
+            entry 'netty-resolver-dns'
+            entry 'netty-transport-native-epoll'
+            entry 'netty-transport-native-kqueue'
+            entry 'netty-transport-native-unix-common'
+            entry 'netty-transport'
+        }
+    }
+}
 
 dependencies {
-    compile 'org.scala-lang:scala-library:2.12.8'
-
-    gatlingCompile 'com.warrenstrange:googleauth:1.1.5'
-    compile group: 'io.gatling', name: 'gatling-app', version: '3.1.1'
-
-    compile group: 'io.gatling', name: 'gatling-recorder', version: '3.1.1'
-    compile group: 'io.gatling.highcharts', name: 'gatling-charts-highcharts', version: '3.1.1'
-
+    compile 'org.scala-lang:scala-library:2.12.12'
+    gatlingCompile 'com.warrenstrange:googleauth:1.5.0'
+    compile group: 'io.gatling', name: 'gatling-app', version: '3.3.1'
+    compile group: 'io.gatling', name: 'gatling-recorder', version: '3.3.1'
+    compile group: 'io.gatling.highcharts', name: 'gatling-charts-highcharts', version: '3.3.1'
 }
 
 gatling {
-    toolVersion '3.1.1'
-    scalaVersion '2.12.8'
-    simulations = [ 'uk.gov.hmcts.reform.cmc.performance.simulations.CMCSimulation'
-    ]
+    toolVersion '3.1.3'
+    scalaVersion '2.12.12'
+    simulations = [ 'uk.gov.hmcts.reform.cmc.performance.simulations.CMCSimulation']
 }
 
 test {
@@ -63,8 +103,4 @@ pluginBundle {
     vcsUrl = 'https://github.com/lkishalmi/gradle-gatling-plugin'
     description = 'Gatling Simulation Execution'
     tags = ['gatling', 'load test', 'stress test', 'performance test', 'scala']
-
-
 }
-
-ext ['netty.version'] = '4.0.51.Final'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes>According to Gatling: "There's no security issue here: the generated reports are only
+            meant to be loaded locally from the filesystem, not from a remote server."
+            https://github.com/gatling/gatling/issues/3903
+        </notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2012-6708</cve>
+        <cve>CVE-2015-9251</cve>
+        <cve>CVE-2020-11022</cve>
+        <cve>CVE-2020-11023</cve>
+        <cve>CVE-2019-11358</cve>
+    </suppress>
+    <suppress>
+        <notes>According to Gatling: "There's no security issue here: the generated reports are only
+            meant to be loaded locally from the filesystem, not from a remote server."
+            https://github.com/gatling/gatling/issues/3903
+        </notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2012-6708</cve>
+        <cve>CVE-2015-9251</cve>
+        <cve>CVE-2020-11022</cve>
+    </suppress>
+    <suppress>
+        <notes>Low confidence issue: kotlin-reflect-1.3.72.jar</notes>
+        <filePath regex="true">.*\bkotlin-reflect-1\.3\.72\.jar</filePath>
+        <cve>CVE-2020-15824</cve>
+    </suppress>
+    <suppress>
+        <notes>Low confidence issue: kotlin-stdlib-1.3.72.jar</notes>
+        <filePath regex="true">.*\bkotlin-stdlib-1\.3\.72\.jar</filePath>
+        <cve>CVE-2020-15824</cve>
+    </suppress>
+    <suppress>
+        <notes>Low confidence issue: kotlin-stdlib-.*-1.3.72.jar</notes>
+        <filePath regex="true">.*\bkotlin-stdlib-.*-1\.3\.72\.jar</filePath>
+        <cve>CVE-2020-15824</cve>
+    </suppress>
+</suppressions>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-8253

### Change description ###

Update Gradle and Gatling dependencies to fix existing vulnerabilities, and introduce dependency-check-suppressions.xml for DependencyCheck alerts that can be safely silenced.

This should help the DependencyCheck step of the nightly performance test pipeline go green: https://build.platform.hmcts.net/job/HMCTS_Nightly_CMC/job/cmc-performance-test/job/master/


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
